### PR TITLE
Serializer todo

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -48,3 +48,4 @@ end
 
 # Windows does not include zoneinfo files, so bundle the tzinfo-data gem
 gem 'tzinfo-data', platforms: [:mingw, :mswin, :x64_mingw, :jruby]
+gem 'active_model_serializers'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -39,6 +39,11 @@ GEM
       erubi (~> 1.4)
       rails-dom-testing (~> 2.0)
       rails-html-sanitizer (~> 1.1, >= 1.2.0)
+    active_model_serializers (0.10.12)
+      actionpack (>= 4.1, < 6.2)
+      activemodel (>= 4.1, < 6.2)
+      case_transform (>= 0.2)
+      jsonapi-renderer (>= 0.1.1.beta1, < 0.3)
     activejob (6.1.3.2)
       activesupport (= 6.1.3.2)
       globalid (>= 0.3.6)
@@ -65,6 +70,8 @@ GEM
       msgpack (~> 1.0)
     builder (3.2.4)
     byebug (11.1.3)
+    case_transform (0.2)
+      activesupport
     concurrent-ruby (1.1.9)
     crass (1.0.6)
     database_cleaner (2.0.1)
@@ -97,6 +104,7 @@ GEM
       activesupport (>= 4.2.0)
     i18n (1.8.10)
       concurrent-ruby (~> 1.0)
+    jsonapi-renderer (0.2.2)
     listen (3.5.1)
       rb-fsevent (~> 0.10, >= 0.10.3)
       rb-inotify (~> 0.9, >= 0.9.10)
@@ -197,6 +205,7 @@ PLATFORMS
   x86_64-linux
 
 DEPENDENCIES
+  active_model_serializers
   bootsnap (>= 1.4.4)
   byebug
   database_cleaner

--- a/app/controllers/todos_controller.rb
+++ b/app/controllers/todos_controller.rb
@@ -5,7 +5,8 @@ class TodosController < ApplicationController
   # GET /todos
   def index
     @todos = Todo.all
-    json_response(@todos)
+    # json_response(@todos)
+    render json: @todos, each_serializer: TodoSerializer
   end
 
   # POST /todos
@@ -16,7 +17,8 @@ class TodosController < ApplicationController
 
   # GET /todos/:id
   def show
-    json_response(@todo) # todo declared in private methods
+    # json_response(@todo) # todo declared in private methods}
+    render json: @todo, serializer: TodoSerializer
   end
 
   # PUT /todos/:id

--- a/app/serializers/item_serializer.rb
+++ b/app/serializers/item_serializer.rb
@@ -1,0 +1,3 @@
+class ItemSerializer < ActiveModel::Serializer
+  attributes :id, :name, :done
+end

--- a/app/serializers/todo_serializer.rb
+++ b/app/serializers/todo_serializer.rb
@@ -1,0 +1,4 @@
+class TodoSerializer < ActiveModel::Serializer
+  attributes :id, :title
+  has_many :items
+end


### PR DESCRIPTION
### What?
Now the api returns the todo lists with their respective list of items in a json format.

### Why?
To  make the interface more uniform with a json format. 

### How? 
- Used the active_model_serializer gem    

### Screenshots
The api return is now in the required format.
![image](https://user-images.githubusercontent.com/49876718/123698880-3ab08000-d824-11eb-9b87-07e0c828c262.png)
![image](https://user-images.githubusercontent.com/49876718/123698924-469c4200-d824-11eb-8713-7520fab58312.png)
